### PR TITLE
Replace 'inclusions' by 'inclusion'

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ They can be individually selected with the `-t` or `--type` switch. Multiple plo
 can be made by using `,` as a separator:
 
 ```bash
-asreview plot ace ptsd --type 'inclusions,discovery'
+asreview plot ace ptsd --type 'inclusion,discovery'
 ```
 
 ### Inclusion


### PR DESCRIPTION
This PR fixes a problem in the README. 

```
jonathans-mbp:FMS_use_case_corticosteroiden jonathan$ asreview plot simulation/result_run_1.h5 --type 'inclusions'
WARNING:root:Plotting type "inclusions unknown."
```