### PR TITLE
Install older version of numpy for CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -41,6 +41,7 @@ jobs:
       run: |
         pip install pytest
         pip install --upgrade setuptools>=41.0.0
+        pip install "numpy<1.19"
         pip install asreview[all]==${{ matrix.asr_versions }}
         pip install .
         pytest tests


### PR DESCRIPTION
Somehow the dependency checks find an issue but it doesn't get resolved automatically.